### PR TITLE
Creado archivo de distribucion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+'''
+    ADI Auth client distrubution file
+'''
+
+from setuptools import setup
+
+
+setup(
+    name='adiauthcli',
+    version='1.0',
+    description='Library and tools to access to ADI Auth Service',
+    packages=['adiauthcli'],
+    install_requires=['requests']
+)


### PR DESCRIPTION
Ahora el proyecto es instalable con pip:

`pip install ./`

Por tanto, se puede activar el entorno virtual, instalar y ya se queda listo para usar en vuestros propios proyectos.